### PR TITLE
Use "target": "es6" in default tsconfig.json, because create-react-app includes polyfills for IE9+

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Here's the issue I just experienced with `create-react-app`: https://github.com/facebook/create-react-app/issues/5771

To summarize: TypeScript was giving me type errors because I wanted to use ES6 functions like `Array.fill` and `Object.assign`. I discovered that `create-react-app` uses Babel for all of the JS compilation, and they just strip the types. They use this package to do type-checking in a separate process. They also already include polyfills to support IE9+, so it's fine to use the "es6" target in the default `tsconfig.json` (which tells TypeScript to use ES6 type definitions.)